### PR TITLE
Fix: Resolve Broken Build by Adding Kotlin Script Runtime

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -116,4 +116,5 @@ dependencies {
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
+    implementation(kotlin("script-runtime"))
 }


### PR DESCRIPTION
This PR fixes a broken build issue by adding the necessary dependency for Kotlin Script Runtime.
Key Changes:
Added implementation(kotlin("script-runtime")) to the build.gradle file.